### PR TITLE
Fixes "E474: Invalid argument"

### DIFF
--- a/colors/ayu.vim
+++ b/colors/ayu.vim
@@ -272,6 +272,6 @@ hi! link diffAdded String
 "
 " This is needed for some reason: {{{
 
-let &background = s:style
+let background = s:style
 
 " }}}


### PR DESCRIPTION
This line treats background option set as a get when using the `&background` identifier. It should be `background` without the `&`